### PR TITLE
Fix atmosphere-opening visual bug, and make it 'fast' instead of 'slow'

### DIFF
--- a/app/assets/scripts/modules/Atmosphere.js
+++ b/app/assets/scripts/modules/Atmosphere.js
@@ -27,7 +27,7 @@ class Atmosphere {
         var atmosphereHTML = Handlebars.templates['atmosphere.hbs'](this.data);
 
         // Add to tracklist
-        var $atmosphereHTML = $(atmosphereHTML).hide().prependTo(g.atmosphereManager.$list).show('fast');
+        var $atmosphereHTML = $(atmosphereHTML).hide().prependTo(g.atmosphereManager.$list).slideDown('fast');
 
         this.rigAtmosphereControls($atmosphereHTML);
 

--- a/app/assets/scripts/modules/Atmosphere.js
+++ b/app/assets/scripts/modules/Atmosphere.js
@@ -82,7 +82,6 @@ class Atmosphere {
         $atmosphereHTML.on('click', function(e) {
             e.stopPropagation();    // Don't deselect current atmosphere if it's DOM element is clicked
             g.atmosphereManager.stopEditingTitle();   // but still cancel title editing
-            console.log($atmosphereHTML.height());
         });
 
         // Click atmosphere heading to set the containing atmosphere as active

--- a/app/assets/scripts/modules/Atmosphere.js
+++ b/app/assets/scripts/modules/Atmosphere.js
@@ -27,7 +27,13 @@ class Atmosphere {
         var atmosphereHTML = Handlebars.templates['atmosphere.hbs'](this.data);
 
         // Add to tracklist
-        var $atmosphereHTML = $(atmosphereHTML).hide().prependTo(g.atmosphereManager.$list).slideDown('fast');
+        var $atmosphereHTML = $(atmosphereHTML).prependTo(g.atmosphereManager.$list).hide();
+        
+        // Hack that corrects the jQuery 'snapping' visual bug
+        //  $atmosphereHTML.height() returns an unreliable result if called here, but it's fine 0ms later
+        setTimeout(function() {
+            $atmosphereHTML.show('fast');
+        }, 0);
 
         this.rigAtmosphereControls($atmosphereHTML);
 
@@ -76,6 +82,7 @@ class Atmosphere {
         $atmosphereHTML.on('click', function(e) {
             e.stopPropagation();    // Don't deselect current atmosphere if it's DOM element is clicked
             g.atmosphereManager.stopEditingTitle();   // but still cancel title editing
+            console.log($atmosphereHTML.height());
         });
 
         // Click atmosphere heading to set the containing atmosphere as active

--- a/app/assets/scripts/modules/SearchBar.js
+++ b/app/assets/scripts/modules/SearchBar.js
@@ -27,7 +27,7 @@ class SearchBar {
         );
         g.$autoplayCheckbox.click(function(event) { // refocus on text upon autoplay click
             this.$input.focus();
-        });
+        }.bind(this));
     }
 
     keyPressInSearchBar(e) {

--- a/app/assets/styles/modules/_section.css
+++ b/app/assets/styles/modules/_section.css
@@ -3,7 +3,6 @@
     margin-bottom: 20px;
     position: relative;
     overflow: hidden;
-    width: 200px;
 
     &__heading {
         background-color: $blueberry;

--- a/app/assets/styles/modules/_section.css
+++ b/app/assets/styles/modules/_section.css
@@ -3,6 +3,7 @@
     margin-bottom: 20px;
     position: relative;
     overflow: hidden;
+    width: 200px;
 
     &__heading {
         background-color: $blueberry;
@@ -72,20 +73,7 @@
             background-color: $whitePurple;
         }
 
-        /* Shadow */
-        &::before {
-            content: '';
-            position: absolute;
-            z-index: -1;
-            width: 100%;
-            height: 100%;
-            opacity: 0;
-            border-radius: 5px;
-            box-shadow: 0 2px 15px rgba($deepSea, 1);
-            transition: opacity 0.7s ease-out;
-        }
-
-        /* Top border */
+        /* Border */
         &::after {
             content: '';
             position: absolute;
@@ -112,7 +100,7 @@
                 color: $vanilla;
             }
             
-            &::before, &::after {
+            &::after {
                 opacity: 100;
             }
 

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -11583,7 +11583,13 @@ var Atmosphere = function () {
             var atmosphereHTML = Handlebars.templates['atmosphere.hbs'](this.data);
 
             // Add to tracklist
-            var $atmosphereHTML = (0, _jquery2.default)(atmosphereHTML).hide().prependTo(_GlobalVars.g.atmosphereManager.$list).slideDown('fast');
+            var $atmosphereHTML = (0, _jquery2.default)(atmosphereHTML).prependTo(_GlobalVars.g.atmosphereManager.$list).hide();
+
+            // Hack that corrects the jQuery 'snapping' visual bug
+            //  $atmosphereHTML.height() returns an unreliable result if called here, but it's fine 0ms later
+            setTimeout(function () {
+                $atmosphereHTML.show('fast');
+            }, 0);
 
             this.rigAtmosphereControls($atmosphereHTML);
 
@@ -11636,6 +11642,7 @@ var Atmosphere = function () {
             $atmosphereHTML.on('click', function (e) {
                 e.stopPropagation(); // Don't deselect current atmosphere if it's DOM element is clicked
                 _GlobalVars.g.atmosphereManager.stopEditingTitle(); // but still cancel title editing
+                console.log($atmosphereHTML.height());
             });
 
             // Click atmosphere heading to set the containing atmosphere as active

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -11642,7 +11642,6 @@ var Atmosphere = function () {
             $atmosphereHTML.on('click', function (e) {
                 e.stopPropagation(); // Don't deselect current atmosphere if it's DOM element is clicked
                 _GlobalVars.g.atmosphereManager.stopEditingTitle(); // but still cancel title editing
-                console.log($atmosphereHTML.height());
             });
 
             // Click atmosphere heading to set the containing atmosphere as active

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -11280,7 +11280,7 @@ var SearchBar = function () {
             _GlobalVars.g.$autoplayCheckbox.click(function (event) {
                 // refocus on text upon autoplay click
                 this.$input.focus();
-            });
+            }.bind(this));
         }
     }, {
         key: "keyPressInSearchBar",
@@ -11583,7 +11583,7 @@ var Atmosphere = function () {
             var atmosphereHTML = Handlebars.templates['atmosphere.hbs'](this.data);
 
             // Add to tracklist
-            var $atmosphereHTML = (0, _jquery2.default)(atmosphereHTML).hide().prependTo(_GlobalVars.g.atmosphereManager.$list).show('fast');
+            var $atmosphereHTML = (0, _jquery2.default)(atmosphereHTML).hide().prependTo(_GlobalVars.g.atmosphereManager.$list).slideDown('fast');
 
             this.rigAtmosphereControls($atmosphereHTML);
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1157,7 +1157,6 @@ a {
     margin-bottom: 20px;
     position: relative;
     overflow: hidden;
-    width: 200px;
 
 }
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1157,6 +1157,7 @@ a {
     margin-bottom: 20px;
     position: relative;
     overflow: hidden;
+    width: 200px;
 
 }
 
@@ -1234,23 +1235,7 @@ a {
             background-color: #C7B1D8;
         }
 
-/* Shadow */
-
-.section--atmosphere::before {
-            content: '';
-            position: absolute;
-            z-index: -1;
-            width: 100%;
-            height: 100%;
-            opacity: 0;
-            border-radius: 5px;
-            -webkit-box-shadow: 0 2px 15px rgba(6,20,35, 1);
-                    box-shadow: 0 2px 15px rgba(6,20,35, 1);
-            -webkit-transition: opacity 0.7s ease-out;
-            transition: opacity 0.7s ease-out;
-        }
-
-/* Top border */
+/* Border */
 
 .section--atmosphere::after {
             content: '';
@@ -1278,7 +1263,7 @@ a {
                 color: #F4E2A1;
             }
 
-.section--atmosphere--active::before, .section--atmosphere--active::after {
+.section--atmosphere--active::after {
                 opacity: 100;
             }
 


### PR DESCRIPTION
Fixes #8 in a pretty hacky way. Works, but not 100% sure why.
Notes:
    -jQuery .height() method returns an unreliable result when the element is hidden, which might be related.
    -.show('fast') just looks snappier and lets the user start adjusting sooner.